### PR TITLE
Animate 'html, body' scroll instead of document.body

### DIFF
--- a/src/process-code-on-page.js
+++ b/src/process-code-on-page.js
@@ -67,7 +67,7 @@ function processTernLinks(ternLinks, codeBlock){
                 }, 2000)
 
                 var heightOfTwoLines = 18 * 2;
-                $(document.body).animate({
+                $('html,body').animate({
                     scrollTop: $declarationElements.first().offset().top - heightOfTwoLines
                 });
             })


### PR DESCRIPTION
Thanks for the debugging help! I've changed `$(document.body)` to `$('html,body')`. I've never cared enough to really get to the heart of which browsers, under which circumstances prefer one or the other, but it seems to work. The downside of this approach is that you get two animation complete events, but nothing is listening for that here anyway, so maybe this is fine (and necessary, for some reason?).
